### PR TITLE
Refactor action

### DIFF
--- a/.github/workflows/test-build-cache.yml
+++ b/.github/workflows/test-build-cache.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           environment: .spack/default
           base-image: ubuntu:24.04
-          force: true
 
       - name: Check specs
         run: |

--- a/.github/workflows/test-build-cache.yml
+++ b/.github/workflows/test-build-cache.yml
@@ -2,9 +2,7 @@ name: Test Spack Build-Cache Action
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   smoke:
@@ -14,24 +12,28 @@ jobs:
       packages: write
 
     steps:
-      # 1) Check out this action’s code
-      - name: Checkout action
+      - name: Checkout
         uses: actions/checkout@v4
 
-      # 2) Run our composite action locally
-      - name: Run Spack Build-Cache
+      - name: Set up Spack
+        uses: spack/setup-spack@v2
+
+      # - name: Add spack.numpex
+      #   uses: viperML/spack-repo-action@master
+      #   with:
+      #     repository: numpex/spack.numpex
+
+      - name: Activate Spack build cache
         uses: ./
         with:
-          env-variant: default
-          env-path: .spack
-          repo-packages: numpex/spack.numpex
-          repo-packages-path: spack.numpex
-          mirror: numpex-buildcache
-          mirror-token: ${{ secrets.GITHUB_TOKEN }}
+          environment: .spack/default
           base-image: ubuntu:24.04
-      - name: spack 
+          force: true
+
+      - name: Check specs
         run: |
-          spack find -lv
-          
-          
-          
+          spack spec
+
+      - name: Check programs
+        run: |
+          which -a cmake

--- a/.spack/default/spack.yaml
+++ b/.spack/default/spack.yaml
@@ -3,17 +3,15 @@
 # It describes a set of packages to be installed, along with
 # configuration settings.
 spack:
-  config:
-    install_tree:
-      padded_length: 128
   packages:
     all:
-      compiler: [gcc@14:, clang@14:]
+      compiler: ["gcc@14:", "clang@14:"]
       require: ['target=x86_64_v3']
   definitions:
   - compilers: [gcc@12:]
   specs:
   - $compilers
+  - cmake
   view: true
   concretizer:
     unify: true

--- a/.spack/default/spack.yaml
+++ b/.spack/default/spack.yaml
@@ -12,6 +12,7 @@ spack:
   specs:
   - $compilers
   - cmake
+  - python
   view: true
   concretizer:
     unify: true

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ jobs:
 | ------------------ | ------------------------------------------------------------------------------- | :------: | ---------------------------------------- |
 | `environment`      | Relative path to the Spack environment (e.g. `.`).                              |    ✅     |                                          |
 | `load-environment` | Whether the Spack environment should be loaded to subsequent steps.             |          | `true`                                   |
-| `spack-path`       | Path to the Spack installation, if changed the path for the setup-spack action. |          | `spack`                                  |
 | `mirror`           | OCI registry to push the packages to.                                           |          | `oci://ghcr.io/${{ github.repository }}` |
 | `token`            | OCI token to use for pushing the packages.                                      |          | `${{ github.token }}`                    |
 | `base-image`       | Image name to attach to the packages, to use them as standalone containers.     |          |                                          |

--- a/README.md
+++ b/README.md
@@ -40,14 +40,16 @@ jobs:
 
 ## Inputs
 
-| Input              | Description                                                                     | Required | Default                                  |
-| ------------------ | ------------------------------------------------------------------------------- | :------: | ---------------------------------------- |
-| `environment`      | Relative path to the Spack environment (e.g. `.`).                              |    ✅     |                                          |
-| `load-environment` | Whether the Spack environment should be loaded to subsequent steps.             |          | `true`                                   |
-| `mirror`           | OCI registry to push the packages to.                                           |          | `oci://ghcr.io/${{ github.repository }}` |
-| `token`            | OCI token to use for pushing the packages.                                      |          | `${{ github.token }}`                    |
-| `base-image`       | Image name to attach to the packages, to use them as standalone containers.     |          |                                          |
-| `force`            | Force push packages into the registry.                                          |          | `false`                                  |
+| Input              | Description                                                                 | Required | Default                                  |
+| ------------------ | --------------------------------------------------------------------------- | :------: | ---------------------------------------- |
+| `environment`      | Relative path to the Spack environment (e.g. `.`).                          |    ✅     |                                          |
+| `load-environment` | Whether the Spack environment should be loaded to subsequent steps.         |          | `true`                                   |
+| `mirror`           | OCI registry to push the packages to.                                       |          | `oci://ghcr.io/${{ github.repository }}` |
+| `token`            | OCI token to use for pushing the packages.                                  |          | `${{ github.token }}`                    |
+| `base-image`       | Image name to attach to the packages, to use them as standalone containers. |          |                                          |
+| `force`            | Force push packages into the registry.                                      |          | `false`                                  |
+| `print-logs`       | Whether to show the build logs for `spack install`.                           |          | `false`                                  |
+| `log-name`         | If not empty, upload the build logs with the following name.                |          |                                          |
 
 
 

--- a/action.yml
+++ b/action.yml
@@ -5,80 +5,99 @@ branding:
   color: purple
 
 inputs:
-  # which Spack environment to use (directory under your repo-packages)
-  env-variant:
-    description: "Spack environment variant (e.g. 'default')"
+  environment:
+    description: "Relative path to the Spack environment (e.g. `.`)."
     required: true
-  # path to spack environments
-  env-path:
-    description: "local path to Spack environments"
-    required: false
-    default: ".spack"
-  # where to pull your Spack packages from
-  repo-packages:
-    description: "GitHub repo with your Spack package recipes"
-    required: false
-    default: "numpex/spack.numpex"
-  repo-packages-path:
-    description: "Path to your Spack packages repo"
-    required: false
-    default: "spack.numpex"    
-  # mirror name in Spack
-  mirror:
-    description: "Name of the Spack buildcache mirror"
-    required: true
-    default: "numpex-buildcache"
+    default: ".spack/default"
 
-  # pass in your GitHub token or other OCI password
-  mirror-token:
-    description: "Password/token to push to the mirror (e.g. secrets.GITHUB_TOKEN)"
-    required: true
+  load-environment:
+    description: "Whether the Spack environment should be loaded to subsequent steps."
+    required: false
+    default: "true"
+
+  spack-path:
+    description: "Path to the Spack installation, if changed the path for the setup-spack action."
+    required: false
+    default: "spack"
+
+  token:
+    description: "OCI token to use for pushing the packages."
+    required: false
+    default: "${{ github.token }}"
+
+  mirror:
+    description: "OCI registry to push the packages to."
+    required: false
+    default: "oci://ghcr.io/${{ github.repository }}"
 
   base-image:
-    description: "Base container image for buildcache metadata"
+    description: "Image name to attach to the packages, to use them as standalone containers."
     required: false
-    default: "ubuntu:24.04"
+
+  force:
+    description: "Force push packages into the registry."
+    required: false
+    default: "false"
 
 runs:
   using: composite
   steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        submodules: true
-
-    - name: Set up Spack
-      uses: spack/setup-spack@v2.1.1
-      with:
-        buildcache: true
-        path: _spack
-        color: true
-
-    - name: Checkout Spack packages repo
-      uses: actions/checkout@v4
-      with:
-        repository: ${{ inputs.repo-packages }}
-        path: ${{ inputs.repo-packages-path }}
-        fetch-depth: 1
-
-    - name: Add custom Spack repo
+    - name: Configure Spack
       shell: bash
       run: |
-        . _spack/share/spack/setup-env.sh
-        spack repo add "${{ inputs.repo-packages-path }}"
+        . "${{ inputs.spack-path }}/share/spack/setup-env.sh"
+        spack bootstrap now
 
-    - name: Install & Push buildcache
-      shell: bash
-      env:
-        SPACK_MIRROR_TOKEN: ${{ inputs.mirror-token }}
-      run: |
-        . _spack/share/spack/setup-env.sh
-        spack -e "${{ inputs.env-path }}/${{ inputs.env-variant }}" install --no-check-signature
-        spack -e "${{ inputs.env-path }}/${{ inputs.env-variant }}" mirror set --push \
-          --oci-username "${{ github.actor }}" \
-          --oci-password "${SPACK_MIRROR_TOKEN}" \
-          "${{ inputs.mirror }}"
-        spack -e "${{ inputs.env-path }}/${{ inputs.env-variant }}" buildcache push \
-          --base-image "${{ inputs.base-image }}" \
+        spack \
+          mirror add \
+          --scope site \
           --unsigned \
-          --update-index "${{ inputs.mirror }}"
+          --oci-username ${{ github.repository_owner }} \
+          --oci-password ${{ inputs.token }} \
+          buildcache-numpex \
+          ${{ inputs.mirror }}
+
+        spack compiler find --scope site
+
+        # Sane defaults
+        spack config --scope site add config:install_tree:root:/opt/root
+        spack config --scope site add config:install_tree:padded_length:128
+
+    # Schedule for pushing before installing
+    # If installing fails, push will still be performed
+    - name: Push to cache
+      uses: gacts/run-and-post-run@v1
+      with:
+        # gacts/run-and-post-run calls each line as a separate command, so put everything in a single line
+        # https://github.com/gacts/run-and-post-run/issues/45
+        post: |
+          . "${{ inputs.spack-path }}/share/spack/setup-env.sh" && \
+          spack -e "${{ inputs.environment }}" buildcache \
+            push \
+            --update-index \
+            --with-build-dependencies \
+            $([[ -n "${{ inputs.base-image }}" ]] && echo --base-image "${{ inputs.base-image }}") \
+            $([[ "${{ inputs.force }}" == "true" ]] && echo --force) \
+            buildcache-numpex
+
+    - name: Install Spack environment
+      shell: bash
+      run: |
+        . "${{ inputs.spack-path }}/share/spack/setup-env.sh"
+        spack -e "${{ inputs.environment }}" install
+
+    - name: Automatically load environment
+      if: ${{ inputs.load-environment == 'true' }}
+      shell: bash
+      run: |
+        . "${{ inputs.spack-path }}/share/spack/setup-env.sh"
+        env_file="/tmp/spack-env"
+        spack env activate "${{ inputs.environment }}" --sh > "$env_file"
+        while IFS= read -r line; do
+          if [[ "$line" =~ ^export\ (.*)=(.*)\;$ ]]; then
+            exporting="${BASH_REMATCH[1]}=${BASH_REMATCH[2]}"
+            echo ":: exporting $exporting"
+            echo "$exporting" >> "$GITHUB_ENV"
+          fi
+        done < "$env_file"
+        rm -f "$env_file"

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,11 @@ inputs:
     required: false
     default: "false"
 
+  log-name:
+    description: "If not empty, upload the build logs with the following name"
+    required: false
+    default: ""
+
 runs:
   using: composite
   steps:
@@ -57,28 +62,23 @@ runs:
         spack config --scope site add config:install_tree:root:/opt/root
         spack config --scope site add config:install_tree:padded_length:128
 
-    # Schedule for pushing before installing
-    # If installing fails, push will still be performed
-    - name: Push to cache
-      uses: gacts/run-and-post-run@v1
-      with:
-        # gacts/run-and-post-run calls each line as a separate command, so put everything in a single line
-        # https://github.com/gacts/run-and-post-run/issues/45
-        post: |
-          spack-bash -c "\
-          spack -e "${{ inputs.environment }}" buildcache \
-            push \
-            --update-index \
-            --with-build-dependencies \
-            $([[ -n "${{ inputs.base-image }}" ]] && echo --base-image "${{ inputs.base-image }}") \
-            $([[ "${{ inputs.force }}" == "true" ]] && echo --force) \
-            buildcache-numpex \
-          "
-
     - name: Install Spack environment
       shell: spack-bash {0}
       run: |
-        spack -e "${{ inputs.environment }}" install
+        spack \
+          -e "${{ inputs.environment }}" \
+          install \
+          -vv \
+          --log-format junit \
+          --log-file /tmp/spack-log
+
+    - uses: actions/upload-artifact@v4
+      name: Upload logs
+      if: ${{ inputs.log-name != '' }}
+      with:
+        name: ${{ inputs.log-name }}
+        path: /tmp/spack-log.xml
+        overwrite: true
 
     - name: Automatically load environment
       if: ${{ inputs.load-environment == 'true' }}
@@ -94,3 +94,15 @@ runs:
           fi
         done < "$env_file"
         rm -f "$env_file"
+
+    - name: Push to cache
+      shell: spack-bash {0}
+      run: |
+        spack -e "${{ inputs.environment }}" buildcache \
+          push \
+          --update-index \
+          --with-build-dependencies \
+          $([[ -n "${{ inputs.base-image }}" ]] && echo --base-image "${{ inputs.base-image }}") \
+          $([[ "${{ inputs.force }}" == "true" ]] && echo --force) \
+          buildcache-numpex
+

--- a/action.yml
+++ b/action.yml
@@ -35,9 +35,14 @@ inputs:
     default: "false"
 
   log-name:
-    description: "If not empty, upload the build logs with the following name"
+    description: "If not empty, upload the build logs with the following name."
     required: false
     default: ""
+
+  print-logs:
+    description: "Whether to show the build logs for spack install."
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -68,7 +73,7 @@ runs:
         spack \
           -e "${{ inputs.environment }}" \
           install \
-          -vv \
+          $([[ "${{ inputs.print-logs }}" == "true" ]] && echo -vv) \
           --log-format junit \
           --log-file /tmp/spack-log
 

--- a/action.yml
+++ b/action.yml
@@ -70,12 +70,17 @@ runs:
     - name: Install Spack environment
       shell: spack-bash {0}
       run: |
+        set +e
         spack \
           -e "${{ inputs.environment }}" \
           install \
           $([[ "${{ inputs.print-logs }}" == "true" ]] && echo -vv) \
           --log-format junit \
           --log-file /tmp/spack-log
+
+        SPACK_INSTALL_EXIT_CODE=$?
+        echo "SPACK_INSTALL_EXIT_CODE=$SPACK_INSTALL_EXIT_CODE" >> "$GITHUB_ENV"
+        set -e
 
     - uses: actions/upload-artifact@v4
       name: Upload logs
@@ -84,6 +89,27 @@ runs:
         name: ${{ inputs.log-name }}
         path: /tmp/spack-log.xml
         overwrite: true
+
+    - name: Push to cache
+      shell: spack-bash {0}
+      run: |
+        spack -e "${{ inputs.environment }}" buildcache \
+          push \
+          --update-index \
+          --with-build-dependencies \
+          $([[ -n "${{ inputs.base-image }}" ]] && echo --base-image "${{ inputs.base-image }}") \
+          $([[ "${{ inputs.force }}" == "true" ]] && echo --force) \
+          buildcache-numpex
+
+    - name: Check Spack install result
+      shell: spack-bash {0}
+      run: |
+        if [[ "$SPACK_INSTALL_EXIT_CODE" -ne 0 ]]; then
+          echo "Spack install failed with exit code: $SPACK_INSTALL_EXIT_CODE"
+          exit $SPACK_INSTALL_EXIT_CODE
+        else
+          echo "Spack install completed successfully"
+        fi
 
     - name: Automatically load environment
       if: ${{ inputs.load-environment == 'true' }}
@@ -100,14 +126,4 @@ runs:
         done < "$env_file"
         rm -f "$env_file"
 
-    - name: Push to cache
-      shell: spack-bash {0}
-      run: |
-        spack -e "${{ inputs.environment }}" buildcache \
-          push \
-          --update-index \
-          --with-build-dependencies \
-          $([[ -n "${{ inputs.base-image }}" ]] && echo --base-image "${{ inputs.base-image }}") \
-          $([[ "${{ inputs.force }}" == "true" ]] && echo --force) \
-          buildcache-numpex
 

--- a/action.yml
+++ b/action.yml
@@ -15,11 +15,6 @@ inputs:
     required: false
     default: "true"
 
-  spack-path:
-    description: "Path to the Spack installation, if changed the path for the setup-spack action."
-    required: false
-    default: "spack"
-
   token:
     description: "OCI token to use for pushing the packages."
     required: false
@@ -43,9 +38,8 @@ runs:
   using: composite
   steps:
     - name: Configure Spack
-      shell: bash
+      shell: spack-bash {0}
       run: |
-        . "${{ inputs.spack-path }}/share/spack/setup-env.sh"
         spack bootstrap now
 
         spack \
@@ -71,26 +65,25 @@ runs:
         # gacts/run-and-post-run calls each line as a separate command, so put everything in a single line
         # https://github.com/gacts/run-and-post-run/issues/45
         post: |
-          . "${{ inputs.spack-path }}/share/spack/setup-env.sh" && \
+          spack-bash -c "\
           spack -e "${{ inputs.environment }}" buildcache \
             push \
             --update-index \
             --with-build-dependencies \
             $([[ -n "${{ inputs.base-image }}" ]] && echo --base-image "${{ inputs.base-image }}") \
             $([[ "${{ inputs.force }}" == "true" ]] && echo --force) \
-            buildcache-numpex
+            buildcache-numpex \
+          "
 
     - name: Install Spack environment
-      shell: bash
+      shell: spack-bash {0}
       run: |
-        . "${{ inputs.spack-path }}/share/spack/setup-env.sh"
         spack -e "${{ inputs.environment }}" install
 
     - name: Automatically load environment
       if: ${{ inputs.load-environment == 'true' }}
-      shell: bash
+      shell: spack-bash {0}
       run: |
-        . "${{ inputs.spack-path }}/share/spack/setup-env.sh"
         env_file="/tmp/spack-env"
         spack env activate "${{ inputs.environment }}" --sh > "$env_file"
         while IFS= read -r line; do


### PR DESCRIPTION
The following have been changed:

- Reworked variable names to ones that make more sense.
- `environment` must be provided by the user.
- Pushing is delayed after the build is done.
- Mirrors are sane config defaults auto-applied.

Marking as draft because I want to figure out:
- Declaring extra Spack repos to add (spack.numpex)
- Automatically loading Spack with shell support (spack env activate fails)